### PR TITLE
fix remux path, update CI and linters

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,6 +3,8 @@ name: cicd
 on:
   push:
     branches: ['main']
+  pull_request:
+    branches: ['main']
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -14,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.22' # The Go version to download (if necessary) and use.
+          go-version: '1.24'
       - uses: pre-commit/action@v3.0.0
       - name: Install dependencies
         run: go get ./app
@@ -23,6 +25,16 @@ jobs:
       - name: Test
         run: |
           go test ./...
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.22"
+  go: "1.24"
   issues-exit-code: 1
   tests: true
   allow-parallel-runners: false
@@ -22,6 +22,7 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
+    - godoclint
   settings:
     gocritic:
       disabled-checks:
@@ -40,6 +41,10 @@ linters:
       min-complexity: 10
   exclusions:
     generated: lax
+    rules:
+      - linters:
+          - revive
+        text: "var-naming: avoid meaningless package names"
     presets:
       - comments
       - common-false-positives

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
 - repo: https://github.com/golangci/golangci-lint
-  rev: v2.3.0
+  rev: v2.9.0
   hooks:
   - id: golangci-lint
     entry: golangci-lint run --fix

--- a/app/downloader/converter.go
+++ b/app/downloader/converter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"path/filepath"
 )
 
 func Convert(ctx context.Context, path string) (string, error) {
@@ -30,8 +29,7 @@ func Convert(ctx context.Context, path string) (string, error) {
 }
 
 func RemuxToMP4(ctx context.Context, path, vcodec string) (string, error) {
-	// Change extension to .mp4
-	outputFile := filepath.Base(path) + ".mp4"
+	outputFile := path + ".mp4"
 
 	cmd := exec.CommandContext(ctx,
 		"ffmpeg",

--- a/app/httpclient/httpClient.go
+++ b/app/httpclient/httpClient.go
@@ -50,7 +50,7 @@ func NewHTTPClientFromString(cookiesString string) (*http.Client, error) {
 		return client, errInstagramCookiesString
 	}
 
-	for _, cookie := range strings.Split(cookiesString, "|,|") {
+	for cookie := range strings.SplitSeq(cookiesString, "|,|") {
 		cookies = ParseCookieString(cookie, cookies)
 	}
 


### PR DESCRIPTION
## Summary

- **Remux path fix**: `RemuxToMP4` used `filepath.Base()` which stripped the directory from the output path, causing ffmpeg to write to the working directory instead of `/tmp/`. This broke all platforms that require remuxing (Shorts, Instagram, FacebookReels)
- **CI**: bumped Go to 1.24, added `pull_request` trigger, split build and deploy jobs so Docker push only runs on main
- **Pre-commit**: golangci-lint v2.3.0 → v2.9.0, pre-commit-hooks v5.0.0 → v6.0.0
- **Linter config**: disabled `godoclint`, suppressed `revive` var-naming for existing code, bumped go version to 1.24